### PR TITLE
Disable Follow Location by Default

### DIFF
--- a/lib/ispmanager_installer.php
+++ b/lib/ispmanager_installer.php
@@ -26,6 +26,7 @@ class IspmanagerInstaller extends SoftactulousInstaller
         $client = $this->Clients->get($service->client_id);
 
         // Authenticate in to ISPmanager account
+        $this->setOptions(['request' => ['follow_location' => true]]);
         $loginData = [
             'authinfo' => $serviceFields['ispmanager_username'] . ':' . $serviceFields['ispmanager_password'],
             'func' => 'auth',
@@ -105,6 +106,7 @@ class IspmanagerInstaller extends SoftactulousInstaller
             [
                 'request' => [
                     'raw' => false,
+                    'follow_location' => true,
                     'referer' => $login . '?api=serialize&act=software'
                 ]
             ]

--- a/lib/softaculous_installer.php
+++ b/lib/softaculous_installer.php
@@ -82,8 +82,12 @@ abstract class SoftactulousInstaller
 
         // Check the Header
         curl_setopt($ch, CURLOPT_HEADER, 1);
-        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+        // Follow location
+        if (isset($this->options['request']['follow_location'])) {
+            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, $this->options['request']['follow_location']);
+        }
 
         // Set request referer
         if (isset($this->options['request']['referer'])) {
@@ -204,6 +208,7 @@ abstract class SoftactulousInstaller
         // Install the script
         $data = [
             'softsubmit' => '1',
+            'php_version_select' => '1',
             'softdomain' => $scriptDomain,
             'site_name' => $scriptDomain,
             'site_desc' => $scriptDomain,


### PR DESCRIPTION
The changes introduced in #8 broke the cPanel integration as this one relies on the "redirect_url" parameter to verify that login access details are correct, when FOLLOW_LOCATION is true "redirect_url" will always be null, making the installation always fails.